### PR TITLE
rpm: fixed "line 1: -p: command not found" issue

### DIFF
--- a/packaging/rules/fedora/ring.spec
+++ b/packaging/rules/fedora/ring.spec
@@ -205,11 +205,10 @@ DESTDIR=%{buildroot} make -C client-gnome/build install
 %{_datadir}/dbus-1/interfaces/*
 
 %post
--p /sbin/ldconfig
+/sbin/ldconfig
 /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
 
-%postun
--p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 #for < f24 we have to update the schema explicitly
 %if 0%{?fedora} < 24


### PR DESCRIPTION
I get this every time ring updates:
`packagekitd[13466]: /var/tmp/rpm-tmp.J9f2GR: line 1: -p: command not found`
I checked the rpm docs and found that "-p" can only be used inline and for a single command (an optimization to not run a subshell)
See https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Scriptlets